### PR TITLE
Resizing Eslasticsearch cluster to t2.medium with 20GB storage to red…

### DIFF
--- a/deployment/custom-deployment/lib/cdk-textract-stack.ts
+++ b/deployment/custom-deployment/lib/cdk-textract-stack.ts
@@ -169,9 +169,12 @@ export class CdkTextractStack extends cdk.Stack {
       this.resourceName("ElasticSearchCluster"),
       {
         elasticsearchVersion: "6.5",
-        ebsOptions: {
+        elasticsearchClusterConfig: {
+          instanceType: "t2.medium.elasticsearch"
+        },
+          ebsOptions: {
           ebsEnabled: true,
-          volumeSize: 30,
+          volumeSize: 20,
           volumeType: "gp2"
         }
       }


### PR DESCRIPTION
*Description of changes:*
Resizing Eslasticsearch cluster to t2.medium with 20GB storage to reduce cost by 50% and still provide plenty of performance for demo documents. Customers can tweak this sizing if they want to move to production or run into regions without t2 instances.

My testing showed search performance still < 6ms and indexing performance unchanged from default m4.medium/30gb setting that was previously used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
