### PR TITLE
changed the LINE text separation from whitespace to period followed b…

### DIFF
--- a/lambda/helper/python/comprehendHelper.py
+++ b/lambda/helper/python/comprehendHelper.py
@@ -55,15 +55,15 @@ class ComprehendHelper:
                     # some block may not contain text
                     if  'Text' in block:
                         
-                        # calculate the size of this page if we add this text element + a space separator.
+                        # calculate the size of this page if we add this text element + the ". " separator.
                         # Comprehend has a UTF8 size limit, so we dismiss excessive elements once size is
                         # reached.
-                        projectedSize = len(rawPages[pageResultIndex]) + len(block['Text']) + 1
+                        projectedSize = len(rawPages[pageResultIndex]) + len(block['Text']) + 2
                         
                         # add if page size allows
                         if MAX_COMPREHEND_UTF8_PAGE_SIZE > projectedSize :
                             # add a separator from previous text block
-                            rawPages[pageResultIndex] += " "
+                            rawPages[pageResultIndex] += ". "
                             # text block
                             rawPages[pageResultIndex] += block['Text']
 


### PR DESCRIPTION

*Issue #, if available:*

Comprehend is not handling well some dates and location tokens when textract elements are separated by whitespaces

*Description of changes:*

a period is prepended to the the whitespace separator, which helps Comprehend understand text tokens better

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
